### PR TITLE
Add support for OpenType.js font engine.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "src/third_party/raqm/libraqm"]
 	path = src/third_party/raqm/libraqm
 	url = https://github.com/HOST-Oman/libraqm.git
+[submodule "src/third_party/opentypejs/opentype.js"]
+	path = src/third_party/opentypejs/opentype.js
+	url = https://github.com/nodebox/opentype.js.git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ python check.py --output=report.html --engine=FreeStack
 
 ## Supported Platforms
 
-Currently, the test suite supports only two OpenType implementations:
+Currently, the test suite supports only three OpenType implementations:
 
 * With `--engine=FreeStack`, the tests are run on the free/libre
 open-source text rendering stack with [FreeType](https://www.freetype.org/),
@@ -30,6 +30,9 @@ are used by Linux, Android, ChromeOS, and many other systems.
 
 * With `--engine=CoreText`, the tests are run on Apple’s CoreText.
 This option will work only if you run the test suite on MacOS X.
+
+* With `--engine=OpenType.js`, the tests are run using [OpenType.js](https://github.com/nodebox/opentype.js).
+This option requires Node.js to be installed.
 
 If you’d like to test another OpenType implementation, please go ahead.
 


### PR DESCRIPTION
This includes OpenType.js as a Git submodule, and calls the new `test-render` command in check.py. The "build" step calls `npm install` if the engine is set to `OpenType.js`.

Currently, the test results are "open for improvement" — but at least we now have a good idea :-)

----
<img width="932" alt="screen shot 2017-04-25 at 20 40 54" src="https://cloud.githubusercontent.com/assets/8477/25422985/3571ff88-2a63-11e7-992a-9d69b2bcd2a8.png">



