### PR TITLE
Support earlier versions of Node for fontkit

### DIFF
--- a/src/third_party/fontkit/render
+++ b/src/third_party/fontkit/render
@@ -1,67 +1,72 @@
 #!/usr/bin/env node
 
-let fontkit = require('fontkit');
+var fontkit = require('fontkit');
 
 // Poor man's argument parser
-let argv = {};
-for (let arg of process.argv) {
-  let match = arg.match(/^--(.+)=(.+)$/);
+var argv = {};
+process.argv.forEach(function (arg) {
+  var match = arg.match(/^--(.+)=(.+)$/);
   if (match) {
     argv[match[1]] = match[2];
   }
-}
+});
 
 function render() {
-  let font = fontkit.openSync(argv.font);
+  var font = fontkit.openSync(argv.font);
 
   if (argv.variation) {
-    let settings = {};
-    argv.variation.split(';').forEach(setting => {
-      let parts = setting.split(':');
+    var settings = {};
+    argv.variation.split(';').forEach(function (setting) {
+      var parts = setting.split(':');
       settings[parts[0]] = parts[1];
     });
 
     font = font.getVariation(settings);
   }
 
-  let run = font.layout(argv.render);
-  let gids = {};
+  var run = font.layout(argv.render);
+  var gids = {};
 
-  let glyphs = run.glyphs.map(glyph => {
+  var glyphs = run.glyphs.map(function (glyph) {
     if (gids[glyph.id]) return;
     gids[glyph.id] = true;
 
     // Get path and normalize
-    let path = glyph.getScaledPath(1000).mapPoints((x, y) => [Math.floor(x), Math.floor(y)]);
-    let svgPath = path.toSVG()
+    var path = glyph.getScaledPath(1000).mapPoints(function (x, y) {
+      return [Math.floor(x), Math.floor(y)]
+    });
+
+    var svgPath = path.toSVG()
       .replace(/(\d+) (-?\d+)/g, '$1,$2')
       .replace(/(\d)([A-Z])/g, '$1 $2')
       .replace(/Z([^\s])/g, 'Z $1');
 
     return (
-      `<symbol id="${argv.testcase}.${glyph.name || `gid${glyph.id}`}" overflow="visible">` +
-        `<path d="${svgPath}" />` +
-      `</symbol>`
+      '<symbol id="' + argv.testcase + '.' + (glyph.name || 'gid' + glyph.id) + '" overflow="visible">' +
+        '<path d="' + svgPath + '" />' +
+      '</symbol>'
     );
   });
 
-  let scale = 1 / font.unitsPerEm * 1000;
-  let x = 0, y = 0;
-  let svg = run.glyphs.map((glyph, index) => {
-    let pos = run.positions[index];
-    let xPos = Math.round(x + pos.xOffset * scale);
-    let yPos = Math.round(y + pos.yOffset * scale);
-    let use = `<use x="${xPos}" y="${yPos}" xlink:href="#${argv.testcase}.${glyph.name || `gid${glyph.id}`}" />`;
+  var scale = 1 / font.unitsPerEm * 1000;
+  var x = 0, y = 0;
+  var svg = run.glyphs.map(function (glyph, index) {
+    var pos = run.positions[index];
+    var xPos = Math.round(x + pos.xOffset * scale);
+    var yPos = Math.round(y + pos.yOffset * scale);
+    var use = '<use x="' + xPos + '" y="' + yPos + '" xlink:href="#' + argv.testcase + '.' + (glyph.name || 'gid' + glyph.id) + '" />';
     x += Math.round(pos.xAdvance * scale);
     y += Math.round(pos.yAdvance * scale);
     return use;
   });
 
-  let bbox = [0, font.descent, run.advanceWidth, font.ascent - font.descent].map(x => Math.round(x * scale));
+  var bbox = [0, font.descent, run.advanceWidth, font.ascent - font.descent].map(function (x) {
+    return Math.round(x * scale)
+  });
 
   console.log(
     '<?xml version="1.0" encoding="UTF-8"?>',
-    `<svg version="1.1" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="${bbox.join(' ')}">`,
+    '<svg version="1.1" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="' + bbox.join(' ') + '">',
       glyphs.join('\n'),
       svg.join('\n'),
     '</svg>'


### PR DESCRIPTION
This removes the ES6 syntax that required Node v6 so the tests can be run on earlier versions. I tested back to v0.10. Fixes #36.